### PR TITLE
Revert changes that made the `attach_inlines` parameter to `differential.createcomment` a no-op

### DIFF
--- a/src/applications/differential/conduit/DifferentialCreateCommentConduitAPIMethod.php
+++ b/src/applications/differential/conduit/DifferentialCreateCommentConduitAPIMethod.php
@@ -94,8 +94,17 @@ final class DifferentialCreateCommentConduitAPIMethod
             ->setContent($content));
     }
 
-    // NOTE: The legacy "attach_inlines" flag is now ignored and has no
-    // effect. See T13513.
+    if ($request->getValue('attach_inlines')) {
+      $type_inline = DifferentialTransaction::TYPE_INLINE;
+      $inlines = $this->loadUnsubmittedInlineComments(
+        $viewer,
+        $revision);
+      foreach ($inlines as $inline) {
+        $xactions[] = id(new DifferentialTransaction())
+          ->setTransactionType($type_inline)
+          ->attachComment($inline);
+      }
+    }
 
     // NOTE: The legacy "silent" flag is now ignored and has no effect. See
     // T13042.
@@ -112,6 +121,51 @@ final class DifferentialCreateCommentConduitAPIMethod
       'revisionid'  => $revision->getID(),
       'uri'         => PhabricatorEnv::getURI('/D'.$revision->getID()),
     );
+  }
+
+  public static function loadUnsubmittedInlineComments(
+    PhabricatorUser $viewer,
+    DifferentialRevision $revision) {
+
+    $inlines = id(new DifferentialDiffInlineCommentQuery())
+      ->setViewer($viewer)
+      ->withRevisionPHIDs(array($revision->getPHID()))
+      ->withAuthorPHIDs(array($viewer->getPHID()))
+      ->withHasTransaction(false)
+      ->withIsDeleted(false)
+      ->needReplyToComments(true)
+      ->execute();
+
+    foreach ($inlines as $key => $inline) {
+      $inlines[$key] = DifferentialInlineComment::newFromModernComment(
+        $inline);
+    }
+
+    PhabricatorInlineComment::loadAndAttachVersionedDrafts(
+      $viewer,
+      $inlines);
+
+    // Don't count void inlines when considering draft state.
+    foreach ($inlines as $key => $inline) {
+      if ($inline->isVoidComment($viewer)) {
+        unset($inlines[$key]);
+        continue;
+      }
+
+      // For other inlines: if they have a nonempty draft state, set their
+      // content to the draft state content. We want to submit the comment
+      // as it is currently shown to the user, not as it was stored the last
+      // time they clicked "Save".
+
+      // $draft_content = $inline->getContentForEdit($viewer);
+      // if (strlen($draft_content)) {
+      //   $inline->setContent($draft_content);
+      // }
+    }
+
+    $inlines = mpull($inlines, 'getStorageObject');
+
+    return $inlines;
   }
 
 }


### PR DESCRIPTION
… to `differential.createcomment` a no-op

This reverts commit 397648855f8bc272db1876da8ce2254d3da82fb9.

* Use DifferentialDiffInlineCommentQuery to retrieve inline comments
* Query publishable inline comments
* Restore the `loadUnsubmittedInlineComments` function
* Avoid using `getContentForEdit` since it is removed