### PR TITLE
Fix Drydock plane spinner only doing half a rotation

### DIFF
--- a/webroot/rsrc/css/font/phui-font-icon-base.css
+++ b/webroot/rsrc/css/font/phui-font-icon-base.css
@@ -58,10 +58,10 @@
 }
 
 .ph-spin {
-  -webkit-animation: spin 2s infinite linear;
-  -moz-animation: spin 2s infinite linear;
-  -o-animation: spin 2s infinite linear;
-  animation: spin 2s infinite linear;
+  -webkit-animation: spin 1s infinite linear;
+  -moz-animation: spin 1s infinite linear;
+  -o-animation: spin 1s infinite linear;
+  animation: spin 1s infinite linear;
 }
 @-moz-keyframes spin {
   0% {


### PR DESCRIPTION
This change adjusts the `ph-spin` animation duration from 2s to 1s so that the rotating plane icon in the “Active Operations” list completes a full rotation before the UI refreshes.

Previously, the Drydock live-update logic was re-rendering the operation row roughly once a second, which meant the `<span class="ph-spin">` element was being replaced before the 2s spin animation could finish. The result was a “half spin then snap back” effect: 
![79c51b8728ee9725](https://github.com/user-attachments/assets/d5ffee2b-9354-4736-930e-63f5b91fff7b)

By shortening the animation duration to 1s in CSS, each instance of the spinner is able to complete a full rotation between refreshes, making the animation appear smooth and continuous.

I have not tested this as I don't know how to.

Considered changing the Drydock live update behaviour so that the spinner DOM node is not recreated on each poll, allowing the existing 2s animation to run continuously. This would be more correct but requires a more invasive change to the Javelin behaviour and is harder to keep in sync with upstream. The CSS-only tweak is smaller has a smaller blast radius.