### PR TITLE
Put revision back in "Changes Planned" when revision in "Request Changes" state is updated

### DIFF
--- a/src/applications/differential/conduit/DifferentialUpdateRevisionConduitAPIMethod.php
+++ b/src/applications/differential/conduit/DifferentialUpdateRevisionConduitAPIMethod.php
@@ -50,6 +50,7 @@ final class DifferentialUpdateRevisionConduitAPIMethod
 
     $diff = id(new DifferentialDiffQuery())
       ->setViewer($viewer)
+      ->needReview($needs_review)
       ->withIDs(array($request->getValue('diffid')))
       ->executeOne();
     if (!$diff) {
@@ -60,7 +61,6 @@ final class DifferentialUpdateRevisionConduitAPIMethod
       ->setViewer($request->getUser())
       ->withIDs(array($request->getValue('id')))
       ->needReviewers(true)
-      ->needReview($request->getValue('needs-review'))
       ->needActiveDiffs(true)
       ->requireCapabilities(
         array(

--- a/src/applications/differential/conduit/DifferentialUpdateRevisionConduitAPIMethod.php
+++ b/src/applications/differential/conduit/DifferentialUpdateRevisionConduitAPIMethod.php
@@ -27,6 +27,7 @@ final class DifferentialUpdateRevisionConduitAPIMethod
       'diffid'    => 'required diffid',
       'fields'    => 'required dict',
       'message'   => 'required string',
+      'needs-review' => 'optional bool',
     );
   }
 
@@ -45,6 +46,7 @@ final class DifferentialUpdateRevisionConduitAPIMethod
 
   protected function execute(ConduitAPIRequest $request) {
     $viewer = $request->getUser();
+    $needs_review = $request->getValue('needs-review', false);
 
     $diff = id(new DifferentialDiffQuery())
       ->setViewer($viewer)
@@ -53,6 +55,11 @@ final class DifferentialUpdateRevisionConduitAPIMethod
     if (!$diff) {
       throw new ConduitException('ERR_BAD_DIFF');
     }
+
+    $xactions[] = id(new DifferentialTransaction())
+      ->setTransactionType(DifferentialTransaction::TYPE_UPDATE)
+      ->setMetadataValue('needs-review', $needs_review)
+      ->setNewValue($diff);
 
     $revision = id(new DifferentialRevisionQuery())
       ->setViewer($request->getUser())

--- a/src/applications/differential/conduit/DifferentialUpdateRevisionConduitAPIMethod.php
+++ b/src/applications/differential/conduit/DifferentialUpdateRevisionConduitAPIMethod.php
@@ -56,15 +56,11 @@ final class DifferentialUpdateRevisionConduitAPIMethod
       throw new ConduitException('ERR_BAD_DIFF');
     }
 
-    $xactions[] = id(new DifferentialTransaction())
-      ->setTransactionType(DifferentialTransaction::TYPE_UPDATE)
-      ->setMetadataValue('needs-review', $needs_review)
-      ->setNewValue($diff);
-
     $revision = id(new DifferentialRevisionQuery())
       ->setViewer($request->getUser())
       ->withIDs(array($request->getValue('id')))
       ->needReviewers(true)
+      ->needReview($request->getValue('needs-review'))
       ->needActiveDiffs(true)
       ->requireCapabilities(
         array(

--- a/src/applications/differential/editor/DifferentialTransactionEditor.php
+++ b/src/applications/differential/editor/DifferentialTransactionEditor.php
@@ -474,7 +474,7 @@ final class DifferentialTransactionEditor
       // This revision was "Needs Revision", but no longer has any rejecting
       // reviewers. This usually happens after the last rejecting reviewer
       // resigns or is removed. Put the revision back in "Needs Review".
-      $new_status = DifferentialRevisionStatus::NEEDS_REVIEW;
+      $new_status = DifferentialRevisionStatus::CHANGES_PLANNED;
     }
 
     if ($new_status === null) {

--- a/src/applications/differential/editor/DifferentialTransactionEditor.php
+++ b/src/applications/differential/editor/DifferentialTransactionEditor.php
@@ -536,11 +536,11 @@ final class DifferentialTransactionEditor
   protected function shouldSendMail(
     PhabricatorLiskDAO $object,
     array $xactions) {
-      // Don't notify reviewers for revisions in "changes planned" / "request changes" state
-      if ($object->isChangePlanned() || $object->isNeedsRevision()) {
-        return false;
-      }
-      return true;
+    // Don't notify reviewers for revisions in "changes planned" / "request changes" state
+    if ($object->isChangePlanned() || $object->isNeedsRevision()) {
+      return false;
+    }
+    return true;
   }
 
   protected function getMailTo(PhabricatorLiskDAO $object) {

--- a/src/applications/differential/editor/DifferentialTransactionEditor.php
+++ b/src/applications/differential/editor/DifferentialTransactionEditor.php
@@ -536,7 +536,11 @@ final class DifferentialTransactionEditor
   protected function shouldSendMail(
     PhabricatorLiskDAO $object,
     array $xactions) {
-    return true;
+      // Don't notify reviewers for revisions in "changes planned" / "request changes" state
+      if ($object->isChangePlanned() || $object->isNeedsRevision()) {
+        return false;
+      }
+      return true;
   }
 
   protected function getMailTo(PhabricatorLiskDAO $object) {

--- a/src/applications/differential/editor/DifferentialTransactionEditor.php
+++ b/src/applications/differential/editor/DifferentialTransactionEditor.php
@@ -471,9 +471,9 @@ final class DifferentialTransactionEditor
       // reviewer resigns or is removed.
       $new_status = DifferentialRevisionStatus::NEEDS_REVIEW;
     } else if ($was_revision) {
-      // This revision was "Needs Revision", but no longer has any rejecting
+      // This revision no longer has any rejecting
       // reviewers. This usually happens after the last rejecting reviewer
-      // resigns or is removed. Put the revision back in "Needs Review".
+      // resigns or is removed. Put the revision in "Changes Planned".
       $new_status = DifferentialRevisionStatus::CHANGES_PLANNED;
     }
 

--- a/src/applications/differential/editor/DifferentialTransactionEditor.php
+++ b/src/applications/differential/editor/DifferentialTransactionEditor.php
@@ -409,23 +409,23 @@ final class DifferentialTransactionEditor
     $was_revision = $revision->isNeedsRevision();
     $was_review = $revision->isNeedsReview();
 
-    // Revisions should not transition out of "Request Changes"
-    // or "Changes Planned" state unless the "needs-review" flag
-    // has been passed from arcanist
-    if ($was_change_planned || $was_revision) {
-      $needs_review = false;
-      // Check if any transaction has needs-review flag
-      foreach ($xactions as $xaction) {
-        if ($xaction->getMetadataValue('needs-review')) {
-          $needs_review = true;
-          break;
-        }
-      }
+    // // Revisions should not transition out of "Request Changes"
+    // // or "Changes Planned" state unless the "needs-review" flag
+    // // has been passed from arcanist
+    // if ($was_change_planned || $was_revision) {
+    //   $needs_review = false;
+    //   // Check if any transaction has needs-review flag
+    //   foreach ($xactions as $xaction) {
+    //     if ($xaction->getMetadataValue('needs-review')) {
+    //       $needs_review = true;
+    //       break;
+    //     }
+    //   }
 
-      if (!$needs_review) {
-        return $xactions;
-      }
-    }
+    //   if (!$needs_review) {
+    //     return $xactions;
+    //   }
+    // }
 
     if (!$was_accepted && !$was_revision && !$was_review) {
       // Revisions can't transition out of other statuses (like closed or

--- a/src/applications/differential/editor/DifferentialTransactionEditor.php
+++ b/src/applications/differential/editor/DifferentialTransactionEditor.php
@@ -404,9 +404,29 @@ final class DifferentialTransactionEditor
     DifferentialRevision $revision,
     array $xactions) {
 
+    $was_change_planned = $revision->isChangePlanned();
     $was_accepted = $revision->isAccepted();
     $was_revision = $revision->isNeedsRevision();
     $was_review = $revision->isNeedsReview();
+
+    // Revisions should not transition out of "Request Changes"
+    // or "Changes Planned" state unless the "needs-review" flag
+    // has been passed from arcanist
+    if ($was_change_planned || $was_revision) {
+      $needs_review = false;
+      // Check if any transaction has needs-review flag
+      foreach ($xactions as $xaction) {
+        if ($xaction->getMetadataValue('needs-review')) {
+          $needs_review = true;
+          break;
+        }
+      }
+
+      if (!$needs_review) {
+        return $xactions;
+      }
+    }
+
     if (!$was_accepted && !$was_revision && !$was_review) {
       // Revisions can't transition out of other statuses (like closed or
       // abandoned) as a side effect of reviewer status changes.
@@ -471,7 +491,7 @@ final class DifferentialTransactionEditor
       // reviewer resigns or is removed.
       $new_status = DifferentialRevisionStatus::NEEDS_REVIEW;
     } else if ($was_revision) {
-      // This revision no longer has any rejecting
+      // This revision was "Needs Revision", and no longer has any rejecting
       // reviewers. This usually happens after the last rejecting reviewer
       // resigns or is removed. Put the revision in "Changes Planned".
       $new_status = DifferentialRevisionStatus::CHANGES_PLANNED;
@@ -536,10 +556,19 @@ final class DifferentialTransactionEditor
   protected function shouldSendMail(
     PhabricatorLiskDAO $object,
     array $xactions) {
+
+    // Check if any transaction has needs-review flag
+    foreach ($xactions as $xaction) {
+      if ($xaction->getMetadataValue('needs-review')) {
+        return true;
+      }
+    }
+
     // Don't notify reviewers for revisions in "changes planned" / "request changes" state
     if ($object->isChangePlanned() || $object->isNeedsRevision()) {
       return false;
     }
+
     return true;
   }
 

--- a/src/applications/differential/query/DifferentialDiffQuery.php
+++ b/src/applications/differential/query/DifferentialDiffQuery.php
@@ -12,6 +12,7 @@ final class DifferentialDiffQuery
 
   private $needChangesets = false;
   private $needProperties;
+  private $requestReview = false;
 
   public function withIDs(array $ids) {
     $this->ids = $ids;
@@ -50,6 +51,22 @@ final class DifferentialDiffQuery
 
   public function needProperties($need_properties) {
     $this->needProperties = $need_properties;
+    return $this;
+  }
+
+  /**
+   * Set whether or not the user has passed --needs-review flag,
+   * indicating query is ready for review and
+   * should send notifications to associated reviewers.
+   *
+   * @param bool True to update revision to "Needs Review" and
+   * send notifications to reviewers.
+   *
+   * @return this
+   * @task config
+   */
+  public function requestReview($requestReview) {
+    $this->requestReview = $requestReview;
     return $this;
   }
 

--- a/src/applications/differential/query/DifferentialRevisionQuery.php
+++ b/src/applications/differential/query/DifferentialRevisionQuery.php
@@ -34,7 +34,8 @@ final class DifferentialRevisionQuery
   private $needDiffIDs        = false;
   private $needCommitPHIDs    = false;
   private $needHashes         = false;
-  private $needReviewers = false;
+  private $needReviewers      = false;
+  private $needReview         = false;
   private $needReviewerAuthority;
   private $needDrafts;
   private $needFlags;
@@ -282,6 +283,22 @@ final class DifferentialRevisionQuery
    */
   public function needReviewers($need_reviewers) {
     $this->needReviewers = $need_reviewers;
+    return $this;
+  }
+
+
+  /**
+   * Set whether or not the query is ready for review and
+   * should send notifications to associated reviewers.
+   *
+   * @param bool True to mark revision as "Needs Review" and
+   * send notifications to reviewers.
+   *
+   * @return this
+   * @task config
+   */
+  public function needReview($need_review) {
+    $this->needReview = $need_review;
     return $this;
   }
 

--- a/src/applications/differential/query/DifferentialRevisionQuery.php
+++ b/src/applications/differential/query/DifferentialRevisionQuery.php
@@ -35,7 +35,6 @@ final class DifferentialRevisionQuery
   private $needCommitPHIDs    = false;
   private $needHashes         = false;
   private $needReviewers      = false;
-  private $needReview         = false;
   private $needReviewerAuthority;
   private $needDrafts;
   private $needFlags;
@@ -283,22 +282,6 @@ final class DifferentialRevisionQuery
    */
   public function needReviewers($need_reviewers) {
     $this->needReviewers = $need_reviewers;
-    return $this;
-  }
-
-
-  /**
-   * Set whether or not the query is ready for review and
-   * should send notifications to associated reviewers.
-   *
-   * @param bool True to mark revision as "Needs Review" and
-   * send notifications to reviewers.
-   *
-   * @return this
-   * @task config
-   */
-  public function needReview($need_review) {
-    $this->needReview = $need_review;
     return $this;
   }
 

--- a/src/applications/differential/storage/DifferentialDiff.php
+++ b/src/applications/differential/storage/DifferentialDiff.php
@@ -39,6 +39,8 @@ final class DifferentialDiff
 
   protected $viewPolicy;
 
+  protected $requestReview;
+
   private $unsavedChangesets = array();
   private $changesets = self::ATTACHABLE;
   private $revision = self::ATTACHABLE;
@@ -66,6 +68,7 @@ final class DifferentialDiff
         'bookmark' => 'text255?',
         'repositoryUUID' => 'text64?',
         'commitPHID' => 'phid?',
+        'requestReview' => 'bool?',
 
         // T6203/NULLABILITY
         // These should be non-null; all diffs should have a creation method
@@ -361,6 +364,16 @@ final class DifferentialDiff
 
   public function getDiffProperties() {
     return $this->assertAttached($this->properties);
+  }
+
+    public function getRequestReview() {
+    return $this->getProperty(self::PROPERTY_REQUEST_REVIEW, false);
+  }
+
+  public function setRequestReview($requestReview) {
+    return $this->setProperty(
+      self::PROPERTY_REQUEST_REVIEW,
+      $requestReview);
   }
 
   public function attachBuildable(HarbormasterBuildable $buildable = null) {

--- a/src/applications/differential/storage/DifferentialRevision.php
+++ b/src/applications/differential/storage/DifferentialRevision.php
@@ -36,6 +36,7 @@ final class DifferentialRevision extends DifferentialDAO
   protected $branchName;
   protected $repositoryPHID;
   protected $activeDiffPHID;
+  protected $needs_review;
 
   protected $viewPolicy = PhabricatorPolicies::POLICY_USER;
   protected $editPolicy = PhabricatorPolicies::POLICY_USER;
@@ -698,6 +699,16 @@ final class DifferentialRevision extends DifferentialDAO
     return $this->setProperty(
       self::PROPERTY_SHOULD_BROADCAST,
       $should_broadcast);
+  }
+
+  public function getNeedsReview() {
+    return $this->getProperty(self::PROPERTY_NEEDS_REVIEW, false);
+  }
+
+  public function setNeedsReview($needs_review) {
+    return $this->setProperty(
+      self::PROPERTY_NEEDS_REVIEW,
+      $needs_review);
   }
 
   public function setAddedLineCount($count) {

--- a/src/applications/differential/storage/DifferentialRevision.php
+++ b/src/applications/differential/storage/DifferentialRevision.php
@@ -36,7 +36,6 @@ final class DifferentialRevision extends DifferentialDAO
   protected $branchName;
   protected $repositoryPHID;
   protected $activeDiffPHID;
-  protected $needs_review;
 
   protected $viewPolicy = PhabricatorPolicies::POLICY_USER;
   protected $editPolicy = PhabricatorPolicies::POLICY_USER;
@@ -699,16 +698,6 @@ final class DifferentialRevision extends DifferentialDAO
     return $this->setProperty(
       self::PROPERTY_SHOULD_BROADCAST,
       $should_broadcast);
-  }
-
-  public function getNeedsReview() {
-    return $this->getProperty(self::PROPERTY_NEEDS_REVIEW, false);
-  }
-
-  public function setNeedsReview($needs_review) {
-    return $this->setProperty(
-      self::PROPERTY_NEEDS_REVIEW,
-      $needs_review);
   }
 
   public function setAddedLineCount($count) {


### PR DESCRIPTION
- Also stop notifying/emailing reviewers of updates when the revision is in "Changes Planned" or "Request Changes" state