### PR TITLE
Revert "Prevent revisions being moved from "Changes Planned/Requested" to "Needs Review" automatically (#8)"

### DIFF
--- a/src/applications/differential/xaction/DifferentialRevisionUpdateTransaction.php
+++ b/src/applications/differential/xaction/DifferentialRevisionUpdateTransaction.php
@@ -59,6 +59,8 @@ final class DifferentialRevisionUpdateTransaction
     }
 
     $should_update =
+      $object->isNeedsRevision() ||
+      $object->isChangePlanned() ||
       $object->isAbandoned();
     if ($should_update) {
       return true;


### PR DESCRIPTION
This reverts commit 94e5f883622ea55f45a8fa6a1bf6d6bf4e533f88.

We need to make some changes to drydock to debug why it is slow, and we don't want to roll out the revision status changes until we have a flag in arcanist to restore the previous behaviour.