### PR TITLE
Add some additional observability to Drydock commands

### DIFF
--- a/src/applications/drydock/blueprint/DrydockWorkingCopyBlueprintImplementation.php
+++ b/src/applications/drydock/blueprint/DrydockWorkingCopyBlueprintImplementation.php
@@ -270,6 +270,11 @@ final class DrydockWorkingCopyBlueprintImplementation
     DrydockBlueprint $blueprint,
     DrydockResource $resource,
     DrydockLease $lease) {
+    /**
+     * activateLease() prepares the Working Copy for the action to be performed.
+     * Meaning that it cleans the git repository and makes sure it's on the
+     * correct reference.
+     */
 
     $host_lease = $this->loadHostLease($resource);
     $command_type = DrydockCommandInterface::INTERFACE_TYPE;
@@ -313,6 +318,7 @@ final class DrydockWorkingCopyBlueprintImplementation
         $arg[] = $branch;
       }
 
+      // TODO: log this
       $this->newExecvFuture($interface, $cmd, $arg)
         ->setTimeout($repository->getEffectiveCopyTimeLimit())
         ->resolvex();
@@ -339,9 +345,10 @@ final class DrydockWorkingCopyBlueprintImplementation
         $arg[] = $ref_ref;
 
         try {
-          $this->newExecvFuture($interface, $cmd, $arg)
+          [$stdout, $stderr] = $this->newExecvFuture($interface, $cmd, $arg)
             ->setTimeout($repository->getEffectiveCopyTimeLimit())
             ->resolvex();
+          // TODO: log this
         } catch (CommandException $ex) {
           $display_command = csprintf(
             'git fetch %R %R',
@@ -650,6 +657,7 @@ final class DrydockWorkingCopyBlueprintImplementation
     $commands = implode(' && ', $commands);
     $argv = array_merge(array($commands), $arguments);
 
+    // TODO: could log here
     return call_user_func_array(array($interface, 'getExecFuture'), $argv);
   }
 

--- a/src/applications/drydock/blueprint/DrydockWorkingCopyBlueprintImplementation.php
+++ b/src/applications/drydock/blueprint/DrydockWorkingCopyBlueprintImplementation.php
@@ -318,7 +318,6 @@ final class DrydockWorkingCopyBlueprintImplementation
         $arg[] = $branch;
       }
 
-      // TODO: log this
       $this->newExecvFuture($interface, $cmd, $arg)
         ->setTimeout($repository->getEffectiveCopyTimeLimit())
         ->resolvex();
@@ -348,7 +347,6 @@ final class DrydockWorkingCopyBlueprintImplementation
           [$stdout, $stderr] = $this->newExecvFuture($interface, $cmd, $arg)
             ->setTimeout($repository->getEffectiveCopyTimeLimit())
             ->resolvex();
-          // TODO: log this
         } catch (CommandException $ex) {
           $display_command = csprintf(
             'git fetch %R %R',
@@ -657,7 +655,6 @@ final class DrydockWorkingCopyBlueprintImplementation
     $commands = implode(' && ', $commands);
     $argv = array_merge(array($commands), $arguments);
 
-    // TODO: could log here
     return call_user_func_array(array($interface, 'getExecFuture'), $argv);
   }
 

--- a/src/applications/drydock/blueprint/DrydockWorkingCopyBlueprintImplementation.php
+++ b/src/applications/drydock/blueprint/DrydockWorkingCopyBlueprintImplementation.php
@@ -344,7 +344,7 @@ final class DrydockWorkingCopyBlueprintImplementation
         $arg[] = $ref_ref;
 
         try {
-          [$stdout, $stderr] = $this->newExecvFuture($interface, $cmd, $arg)
+          $this->newExecvFuture($interface, $cmd, $arg)
             ->setTimeout($repository->getEffectiveCopyTimeLimit())
             ->resolvex();
         } catch (CommandException $ex) {

--- a/src/applications/drydock/controller/DrydockLeaseViewController.php
+++ b/src/applications/drydock/controller/DrydockLeaseViewController.php
@@ -195,7 +195,7 @@ final class DrydockLeaseViewController extends DrydockLeaseController {
       $view->addSectionHeader(
         pht('Attributes'), 'fa-list-ul');
       foreach ($attributes as $key => $value) {
-        $view->addProperty($key, $value);
+        $view->addProperty($key, json_encode($value));
       }
     }
 

--- a/src/applications/drydock/interface/command/DrydockSSHCommandInterface.php
+++ b/src/applications/drydock/interface/command/DrydockSSHCommandInterface.php
@@ -50,13 +50,20 @@ final class DrydockSSHCommandInterface extends DrydockCommandInterface {
       $flags[] = 'ConnectTimeout='.$this->connectTimeout;
     }
 
+    $ssh_host = $this->getConfig('host');
+
+    echo tsprintf(
+      "Drydock running command over SSH on host %s. Command: %s",
+      $ssh_host,
+      $full_command->getMaskedString(),
+    );
     return new ExecFuture(
       'ssh %Ls -l %P -p %s -i %P %s -- %s',
       $flags,
       $credential->getUsernameEnvelope(),
       $this->getConfig('port'),
       $credential->getKeyfileEnvelope(),
-      $this->getConfig('host'),
+      $ssh_host,
       $full_command);
   }
 }


### PR DESCRIPTION
- Json encoding lease attributes displayed on the UI, because otherwise they're displaying only the values, not the keys, of the map.
- Log which commands we're running on the drydock host
- Add some docs to activateLease()