### PR TITLE
Switch to logging drydock commands on stderr

### DIFF
--- a/src/applications/drydock/interface/command/DrydockSSHCommandInterface.php
+++ b/src/applications/drydock/interface/command/DrydockSSHCommandInterface.php
@@ -52,11 +52,11 @@ final class DrydockSSHCommandInterface extends DrydockCommandInterface {
 
     $ssh_host = $this->getConfig('host');
 
-    echo tsprintf(
+    fwrite(STDERR, tsprintf(
       "Drydock running command over SSH on host %s. Command: %s",
       $ssh_host,
       $full_command->getMaskedString(),
-    );
+    ));
     return new ExecFuture(
       'ssh %Ls -l %P -p %s -i %P %s -- %s',
       $flags,


### PR DESCRIPTION
Oops, echoing them probably means they were ending up in some random page or something

this `fwrite(STDERR` syntax is, frustratingly, not in [the php docs on fwrite](https://www.php.net/manual/en/function.fwrite.php), but it's used elsewhere in phorge and various people online comment on using it, so.. it must be real, right?
