### PR TITLE
Add timing metrics to the git operations which Drydock performs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "kelvinmo/simplejwt": "0.3.0",
-        "promphp/prometheus_client_php": "^2.2",
+        "promphp/prometheus_client_php": "^2.14.1",
         "ext-redis": "^5.3.4"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b63413f26db5ad44935c307038516ea8",
+    "content-hash": "2de3b3d2ab2adb1a1745840f07c81c89",
     "packages": [
         {
             "name": "kelvinmo/simplejwt",
@@ -66,21 +66,21 @@
         },
         {
             "name": "promphp/prometheus_client_php",
-            "version": "v2.3.0",
+            "version": "v2.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PromPHP/prometheus_client_php.git",
-                "reference": "6e30c28d19acb65e5d9a445c8c9bdb11b0d56c73"
+                "reference": "a283aea8269287dc35313a0055480d950c59ac1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PromPHP/prometheus_client_php/zipball/6e30c28d19acb65e5d9a445c8c9bdb11b0d56c73",
-                "reference": "6e30c28d19acb65e5d9a445c8c9bdb11b0d56c73",
+                "url": "https://api.github.com/repos/PromPHP/prometheus_client_php/zipball/a283aea8269287dc35313a0055480d950c59ac1f",
+                "reference": "a283aea8269287dc35313a0055480d950c59ac1f",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "php": "^7.2|^8.0"
+                "php": "^7.4|^8.0"
             },
             "replace": {
                 "endclothing/prometheus_client_php": "*",
@@ -90,15 +90,16 @@
             "require-dev": {
                 "guzzlehttp/guzzle": "^6.3|^7.0",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^0.12.50",
-                "phpstan/phpstan-phpunit": "^0.12.16",
-                "phpstan/phpstan-strict-rules": "^0.12.5",
-                "phpunit/phpunit": "^8.4|^9.4",
-                "squizlabs/php_codesniffer": "^3.5",
+                "phpstan/phpstan": "^1.5.4",
+                "phpstan/phpstan-phpunit": "^1.1.0",
+                "phpstan/phpstan-strict-rules": "^1.1.0",
+                "phpunit/phpunit": "^9.4",
+                "squizlabs/php_codesniffer": "^3.6",
                 "symfony/polyfill-apcu": "^1.6"
             },
             "suggest": {
                 "ext-apc": "Required if using APCu.",
+                "ext-pdo": "Required if using PDO.",
                 "ext-redis": "Required if using Redis.",
                 "promphp/prometheus_push_gateway_php": "An easy client for using Prometheus PushGateway.",
                 "symfony/polyfill-apcu": "Required if you use APCu on PHP8.0+"
@@ -127,20 +128,20 @@
             "description": "Prometheus instrumentation library for PHP applications.",
             "support": {
                 "issues": "https://github.com/PromPHP/prometheus_client_php/issues",
-                "source": "https://github.com/PromPHP/prometheus_client_php/tree/v2.3.0"
+                "source": "https://github.com/PromPHP/prometheus_client_php/tree/v2.14.1"
             },
-            "time": "2021-09-14T05:39:00+00:00"
+            "time": "2025-04-14T07:59:43+00:00"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "ext-redis": "^5.3.4"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/src/__phutil_library_map__.php
+++ b/src/__phutil_library_map__.php
@@ -4554,6 +4554,7 @@ phutil_register_library_map(array(
     'PhabricatorPrometheusMetric' => 'applications/prometheus/metrics/PhabricatorPrometheusMetric.php',
     'PhabricatorPrometheusMetricCounter' => 'applications/prometheus/metrics/PhabricatorPrometheusMetricCounter.php',
     'PhabricatorPrometheusMetricGauge' => 'applications/prometheus/metrics/PhabricatorPrometheusMetricGauge.php',
+    'PhabricatorPrometheusMetricSummary' => 'applications/prometheus/metrics/PhabricatorPrometheusMetricSummary.php',
     'PhabricatorPrometheusMetricsController' => 'applications/prometheus/controller/PhabricatorPrometheusMetricsController.php',
     'PhabricatorPronounSetting' => 'applications/settings/setting/PhabricatorPronounSetting.php',
     'PhabricatorProtocolLog' => 'infrastructure/log/PhabricatorProtocolLog.php',

--- a/src/applications/drydock/blueprint/DrydockWorkingCopyBlueprintImplementation.php
+++ b/src/applications/drydock/blueprint/DrydockWorkingCopyBlueprintImplementation.php
@@ -320,12 +320,12 @@ final class DrydockWorkingCopyBlueprintImplementation
         $arg[] = $branch;
       }
 
-      $clean_future = $this->newExecvFuture($interface, $cmd, $arg)
-        ->setTimeout($repository->getEffectiveCopyTimeLimit());
       $timer_metric->timeCommand(
         "activate_lease_git_clean",
-        function () use ($clean_future) {
-          $clean_future->resolvex();
+        function () use ($interface, $cmd, $arg, $repository) {
+          $this->newExecvFuture($interface, $cmd, $arg)
+            ->setTimeout($repository->getEffectiveCopyTimeLimit())
+            ->resolvex();
         }
       );
 
@@ -351,12 +351,12 @@ final class DrydockWorkingCopyBlueprintImplementation
         $arg[] = $ref_ref;
 
         try {
-          $fetch_future = $this->newExecvFuture($interface, $cmd, $arg)
-            ->setTimeout($repository->getEffectiveCopyTimeLimit());
           $timer_metric->timeCommand(
             "activate_lease_git_fetch_reference",
-            function () use ($fetch_future) {
-              $fetch_future->resolvex();
+            function () use ($interface, $cmd, $arg, $repository) {
+              $this->newExecvFuture($interface, $cmd, $arg)
+                ->setTimeout($repository->getEffectiveCopyTimeLimit())
+                ->resolvex();
             }
           );
         } catch (CommandException $ex) {

--- a/src/applications/drydock/blueprint/DrydockWorkingCopyBlueprintImplementation.php
+++ b/src/applications/drydock/blueprint/DrydockWorkingCopyBlueprintImplementation.php
@@ -285,6 +285,8 @@ final class DrydockWorkingCopyBlueprintImplementation
 
     $repositories = $this->loadRepositories(ipull($map, 'phid'));
 
+    $timer_metric = new PhabricatorPrometheusDrydockTimingMetric();
+
     $default = null;
     foreach ($map as $directory => $spec) {
       $repository = $repositories[$spec['phid']];
@@ -318,9 +320,14 @@ final class DrydockWorkingCopyBlueprintImplementation
         $arg[] = $branch;
       }
 
-      $this->newExecvFuture($interface, $cmd, $arg)
-        ->setTimeout($repository->getEffectiveCopyTimeLimit())
-        ->resolvex();
+      $clean_future = $this->newExecvFuture($interface, $cmd, $arg)
+        ->setTimeout($repository->getEffectiveCopyTimeLimit());
+      $timer_metric->timeCommand(
+        "activate_lease_git_clean",
+        function () use ($clean_future) {
+          $clean_future->resolvex();
+        }
+      );
 
       if (idx($spec, 'default')) {
         $default = $directory;
@@ -344,9 +351,14 @@ final class DrydockWorkingCopyBlueprintImplementation
         $arg[] = $ref_ref;
 
         try {
-          $this->newExecvFuture($interface, $cmd, $arg)
-            ->setTimeout($repository->getEffectiveCopyTimeLimit())
-            ->resolvex();
+          $fetch_future = $this->newExecvFuture($interface, $cmd, $arg)
+            ->setTimeout($repository->getEffectiveCopyTimeLimit());
+          $timer_metric->timeCommand(
+            "activate_lease_git_fetch_reference",
+            function () use ($fetch_future) {
+              $fetch_future->resolvex();
+            }
+          );
         } catch (CommandException $ex) {
           $display_command = csprintf(
             'git fetch %R %R',
@@ -504,12 +516,18 @@ final class DrydockWorkingCopyBlueprintImplementation
     $src_ref = $merge['src.ref'];
 
 
+    $timer_metric = new PhabricatorPrometheusDrydockTimingMetric();
     try {
-      $interface->execx(
-        'git fetch --no-tags -- %s +%s:%s',
-        $src_uri,
-        $src_ref,
-        $src_ref);
+      $timer_metric->timeCommand(
+        "wc_merge_git_fetch",
+        function () use ($interface, $src_uri, $src_ref) {
+          $interface->execx(
+            'git fetch --no-tags -- %s +%s:%s',
+            $src_uri,
+            $src_ref,
+            $src_ref);
+        }
+      );
     } catch (CommandException $ex) {
       $display_command = csprintf(
         'git fetch %R +%R:%R',
@@ -533,24 +551,34 @@ final class DrydockWorkingCopyBlueprintImplementation
       // NOTE: This can never actually generate a commit because we pass
       // "--squash", but git sometimes runs code to check that a username and
       // email are configured anyway.
-      $interface->execx(
-        'git -c user.name=%s -c user.email=%s merge --no-stat --squash -- %s',
-        'drydock',
-        'drydock@phabricator',
-        $src_ref);
+      $timer_metric->timeCommand(
+        "wc_merge_squash_commit",
+        function () use ($interface, $src_ref) {
+          $interface->execx(
+            'git -c user.name=%s -c user.email=%s merge --no-stat --squash -- %s',
+            'drydock',
+            'drydock@phabricator',
+            $src_ref);
+        }
+      );
     } catch (CommandException $ex) {
       $tmp_branch_name = sprintf(
         '%s-%d',
         self::TMP_BRANCH_PREFIX,
         rand());
       try {
-        $interface->execx(
-          // First we reset HEAD --hard because we may have succeded to git merge --squash
-          // some changes onto HEAD above but failed eg due to merge conflicts so make sure
-          // the HEAD is clean before attempting the rebase
-          'git reset HEAD --hard && git checkout -b %s %s',
-          $tmp_branch_name,
-          $src_ref);
+        // First we reset HEAD --hard because we may have succeded to git merge --squash
+        // some changes onto HEAD above but failed eg due to merge conflicts so make sure
+        // the HEAD is clean before attempting the rebase
+        $timer_metric->timeCommand(
+          "wc_merge_reset_after_squash",
+          function () use ($interface, $tmp_branch_name, $src_ref) {
+            $interface->execx(
+              'git reset HEAD --hard && git checkout -b %s %s',
+              $tmp_branch_name,
+              $src_ref);
+          }
+        );
       } catch (CommandException $ex) {
         $display_command = csprintf(
           'git reset HEAD --hard && git checkout -b %s %R',
@@ -565,23 +593,43 @@ final class DrydockWorkingCopyBlueprintImplementation
       }
 
       try {
-        $interface->execx('git rebase -');
+        $timer_metric->timeCommand(
+          "wc_merge_rebase",
+          function () use ($interface) {
+            $interface->execx('git rebase -');
+          }
+        );
       } catch (CommandException $ex) {
         $error = DrydockCommandError::newFromCommandException($ex)
           ->setPhase(self::PHASE_REBASE)
           ->setDisplayCommand('git rebase -');
         $lease->setAttribute('workingcopy.vcs.error', $error->toDictionary());
 
-        $interface->execx('git rebase --abort && git checkout -');
-        $interface->execx(
-          'git branch -D `git branch | grep -E "%s-.*"`',
-          self::TMP_BRANCH_PREFIX);
+        $timer_metric->timeCommand(
+          "wc_merge_abort_rebase",
+          function () use ($interface) {
+            $interface->execx('git rebase --abort && git checkout -');
+          }
+        );
+        $timer_metric->timeCommand(
+          "wc_merge_delete_tmp_branch",
+          function () use ($interface) {
+            $interface->execx(
+              'git branch -D `git branch | grep -E "%s-.*"`',
+              self::TMP_BRANCH_PREFIX);
+          }
+        );
 
         throw $ex;
       }
 
       try {
-        $interface->execx('git checkout -');
+        $timer_metric->timeCommand(
+          "wc_merge_squashmerge_checkout",
+          function () use ($interface) {
+            $interface->execx('git checkout -');
+          }
+        );
       } catch (CommandException $ex) {
 
         $error = DrydockCommandError::newFromCommandException($ex)
@@ -602,7 +650,12 @@ final class DrydockWorkingCopyBlueprintImplementation
         $tmp_branch_name);
 
       try {
-        $interface->execx('%C', $real_command);
+        $timer_metric->timeCommand(
+          "wc_merge_squashmerge_merge",
+          function () use ($interface, $real_command) {
+            $interface->execx('%C', $real_command);
+          }
+        );
       } catch (CommandException $ex) {
         // display the full rebase command so the user can debug the full flow
         $display_command = csprintf(
@@ -617,17 +670,27 @@ final class DrydockWorkingCopyBlueprintImplementation
           ->setDisplayCommand($display_command);
 
         $lease->setAttribute('workingcopy.vcs.error', $error->toDictionary());
-        $interface->execx(
-          'git branch -D `git branch | grep -E "%s-.*"`',
-          self::TMP_BRANCH_PREFIX);
+        $timer_metric->timeCommand(
+          "wc_merge_delete_tmp_branch",
+          function () use ($interface) {
+            $interface->execx(
+              'git branch -D `git branch | grep -E "%s-.*"`',
+              self::TMP_BRANCH_PREFIX);
+          }
+        );
 
         throw $ex;
       }
 
       try {
-        $interface->execx(
-          'git branch -D `git branch | grep -E "%s-.*"`',
-          self::TMP_BRANCH_PREFIX);
+        $timer_metric->timeCommand(
+          "wc_merge_delete_tmp_branch",
+          function () use ($interface) {
+            $interface->execx(
+              'git branch -D `git branch | grep -E "%s-.*"`',
+              self::TMP_BRANCH_PREFIX);
+          }
+        );
       } catch (CommandExeption $ex) {
         // ignore it we were just trying to tidy up after ourselves
       }

--- a/src/applications/drydock/metrics/PhabricatorPrometheusDrydockTimingMetric.php
+++ b/src/applications/drydock/metrics/PhabricatorPrometheusDrydockTimingMetric.php
@@ -1,0 +1,31 @@
+<?php
+
+final class PhabricatorPrometheusDrydockTimingMetric extends PhabricatorPrometheusMetricSummary {
+  const CMD_KEY = "command_key";
+
+  public function getName(): string {
+    return 'drydock_command_time_taken_seconds';
+  }
+
+  public function getHelp(): string {
+    return 'A summary of the time taken by various commands ran by Drydock';
+  }
+
+  public function getLabels(): array {
+    return [self::CMD_KEY];
+  }
+
+  public function getValues(): array
+  {
+    // This function is not used, instead we call observe() for each observation.
+    return [];
+  }
+
+  public function timeCommand(string $command_key, callable $function) {
+    $start_time = microtime(true);
+    $function();
+    $end_time = microtime(true);
+    $time_elapsed = $end_time - $start_time;
+    $this->observe($time_elapsed, array(self::CMD_KEY => $command_key));
+  }
+}

--- a/src/applications/drydock/metrics/PhabricatorPrometheusDrydockTimingMetric.php
+++ b/src/applications/drydock/metrics/PhabricatorPrometheusDrydockTimingMetric.php
@@ -15,6 +15,11 @@ final class PhabricatorPrometheusDrydockTimingMetric extends PhabricatorPromethe
     return [self::CMD_KEY];
   }
 
+  public function getMaxAgeSeconds(): int
+  {
+    return 86400;
+  }
+
   public function getValues(): array
   {
     // This function is not used, instead we call observe() for each observation.

--- a/src/applications/drydock/operation/DrydockLandRepositoryOperation.php
+++ b/src/applications/drydock/operation/DrydockLandRepositoryOperation.php
@@ -126,7 +126,7 @@ final class DrydockLandRepositoryOperation
     $timer_metric = new PhabricatorPrometheusDrydockTimingMetric();
     try {
       $timer_metric->timeCommand(
-        "land_operation",
+        "land_operation_git_commit",
         function() use ($future) {
           $future->resolvex();
         });
@@ -146,10 +146,15 @@ final class DrydockLandRepositoryOperation
     }
 
     try {
-      $interface->execx(
-        'git push origin -- %s:%s',
-        'HEAD',
-        $push_dst);
+      $timer_metric->timeCommand(
+        "land_operation_git_push",
+        function() use ($interface, $push_dst) {
+          $interface->execx(
+            'git push origin -- %s:%s',
+            'HEAD',
+            $push_dst);
+        }
+      );
     } catch (CommandException $ex) {
       $display_command = csprintf(
         'git push origin %R:%R',

--- a/src/applications/drydock/operation/DrydockLandRepositoryOperation.php
+++ b/src/applications/drydock/operation/DrydockLandRepositoryOperation.php
@@ -123,8 +123,13 @@ final class DrydockLandRepositoryOperation
 
     $future->write($commit_message);
 
+    $timer_metric = new PhabricatorPrometheusDrydockTimingMetric();
     try {
-      $future->resolvex();
+      $timer_metric->timeCommand(
+        "land_operation",
+        function() use ($future) {
+          $future->resolvex();
+        });
     } catch (CommandException $ex) {
       $display_command = csprintf('git commit');
 

--- a/src/applications/prometheus/metrics/PhabricatorPrometheusMetric.php
+++ b/src/applications/prometheus/metrics/PhabricatorPrometheusMetric.php
@@ -68,7 +68,7 @@ abstract class PhabricatorPrometheusMetric extends Phobject {
         function (string $name) use ($labels) {
           return $labels[$name];
         },
-	      $this->getLabels());
+        $this->getLabels());
       $this->observe($value, $labels);
     }
   }

--- a/src/applications/prometheus/metrics/PhabricatorPrometheusMetric.php
+++ b/src/applications/prometheus/metrics/PhabricatorPrometheusMetric.php
@@ -68,7 +68,7 @@ abstract class PhabricatorPrometheusMetric extends Phobject {
         function (string $name) use ($labels) {
           return $labels[$name];
         },
-	$this->getLabels());
+	      $this->getLabels());
       $this->observe($value, $labels);
     }
   }

--- a/src/applications/prometheus/metrics/PhabricatorPrometheusMetricSummary.php
+++ b/src/applications/prometheus/metrics/PhabricatorPrometheusMetricSummary.php
@@ -12,7 +12,12 @@ abstract class PhabricatorPrometheusMetricSummary extends PhabricatorPrometheusM
       self::METRIC_NAMESPACE,
       $this->getName(),
       $this->getHelp(),
-      $this->getLabels());
+      $this->getLabels(),
+      maxAgeSeconds: $this->getMaxAgeSeconds());
+  }
+
+  public function getMaxAgeSeconds(): int {
+    return 600;
   }
 
   final public function observe(float $value, array $labels): void

--- a/src/applications/prometheus/metrics/PhabricatorPrometheusMetricSummary.php
+++ b/src/applications/prometheus/metrics/PhabricatorPrometheusMetricSummary.php
@@ -1,0 +1,22 @@
+<?php
+
+use Prometheus\CollectorRegistry;
+
+/**
+ * @phutil-external-symbol class CollectorRegistry
+ */
+abstract class PhabricatorPrometheusMetricSummary extends PhabricatorPrometheusMetric {
+
+  final public function register(CollectorRegistry $registry): void {
+    $this->metric = $registry->getOrRegisterSummary(
+      self::METRIC_NAMESPACE,
+      $this->getName(),
+      $this->getHelp(),
+      $this->getLabels());
+  }
+
+  final public function observe(float $value, array $labels): void
+  {
+    $this->metric->observe($value, $labels);
+  }
+}


### PR DESCRIPTION
This means updating our prometheus client and defining how to use a Summary metric, then adding some method to time a passed callable, and then wrapping the various exec and resolve usages with anonymous functions and passing them to that new timeCommand() method.

I've tried to use unique key strings for the timing command labels, but they're a bit messy perhaps? Maybe there could be a stage metric label name too?

I'm not sure if there's a nicer way to pass anonymous functions, either. It seems like the answer is no, in php7 at least.

This will need testing on our development instance before rollout, of course. I have not been able to test it locally or anything.