### PR TITLE
Add conduit endpoint for drydock operation search

### DIFF
--- a/src/__phutil_library_map__.php
+++ b/src/__phutil_library_map__.php
@@ -1258,6 +1258,7 @@ phutil_register_library_map(array(
     'DrydockManagementUpdateResourceWorkflow' => 'applications/drydock/management/DrydockManagementUpdateResourceWorkflow.php',
     'DrydockManagementWorkflow' => 'applications/drydock/management/DrydockManagementWorkflow.php',
     'DrydockObjectAuthorizationView' => 'applications/drydock/view/DrydockObjectAuthorizationView.php',
+    'DrydockOperationSearchConduitAPIMethod' => 'applications/drydock/conduit/DrydockOperationSearchConduitAPIMethod.php',
     'DrydockOperationWorkLogType' => 'applications/drydock/logtype/DrydockOperationWorkLogType.php',
     'DrydockQuery' => 'applications/drydock/query/DrydockQuery.php',
     'DrydockRepositoryOperation' => 'applications/drydock/storage/DrydockRepositoryOperation.php',
@@ -7359,6 +7360,7 @@ phutil_register_library_map(array(
     'DrydockManagementUpdateResourceWorkflow' => 'DrydockManagementWorkflow',
     'DrydockManagementWorkflow' => 'PhabricatorManagementWorkflow',
     'DrydockObjectAuthorizationView' => 'AphrontView',
+    'DrydockOperationSearchConduitAPIMethod' => 'PhabricatorSearchEngineAPIMethod',
     'DrydockOperationWorkLogType' => 'DrydockLogType',
     'DrydockQuery' => 'PhabricatorCursorPagedPolicyAwareQuery',
     'DrydockRepositoryOperation' => array(

--- a/src/applications/drydock/conduit/DrydockOperationSearchConduitAPIMethod.php
+++ b/src/applications/drydock/conduit/DrydockOperationSearchConduitAPIMethod.php
@@ -1,0 +1,18 @@
+<?php
+
+final class DrydockOperationSearchConduitAPIMethod
+  extends PhabricatorSearchEngineAPIMethod {
+
+  public function getAPIMethodName() {
+    return 'drydock.operation.search';
+  }
+
+  public function newSearchEngine() {
+    return new DrydockRepositoryOperationSearchEngine();
+  }
+
+  public function getMethodSummary() {
+    return pht('Retrieve information about Drydock operations.');
+  }
+
+}


### PR DESCRIPTION
So, there's a conduit endpoint for drydock leases, which refer to drydock operations, but no way to get information on drydock operations. We need the information on the drydock operation, in order to link to the revision the lease is associated with.

So, let's try adding a conduit endpoint!

Copied this from DrydockLeaseSearchConduitAPIMethod.php, and it seems like the DrydockRepositoryOperationSearchEngine class already exists, so.. maybe this is easy?
It looks like nowhere else references `DrydockLeaseSearchConduitAPIMethod`, so I don't think anything else needs to reference this new class in order for it to become a drydock operation.

I don't know if it will work, but it would be nice to test out.

