### PR TITLE
Adding some fields to the DrydockRepositoryOperation

### DIFF
--- a/src/__phutil_library_map__.php
+++ b/src/__phutil_library_map__.php
@@ -7364,6 +7364,7 @@ phutil_register_library_map(array(
     'DrydockRepositoryOperation' => array(
       'DrydockDAO',
       'PhabricatorPolicyInterface',
+      'PhabricatorConduitResultInterface',
     ),
     'DrydockRepositoryOperationController' => 'DrydockController',
     'DrydockRepositoryOperationDismissController' => 'DrydockRepositoryOperationController',

--- a/src/applications/drydock/storage/DrydockRepositoryOperation.php
+++ b/src/applications/drydock/storage/DrydockRepositoryOperation.php
@@ -6,7 +6,8 @@
  */
 final class DrydockRepositoryOperation extends DrydockDAO
   implements
-    PhabricatorPolicyInterface {
+    PhabricatorPolicyInterface,
+    PhabricatorConduitResultInterface {
 
   const STATE_WAIT = 'wait';
   const STATE_WORK = 'work';
@@ -285,4 +286,35 @@ final class DrydockRepositoryOperation extends DrydockDAO
   }
 
 
+  public function getFieldSpecificationsForConduit()
+  {
+    return array(
+      id(new PhabricatorConduitSearchFieldSpecification())
+        ->setKey('objectPHID')
+        ->setType('string')
+        ->setDescription(pht('PHID of the object this operation is working on.')),
+      id(new PhabricatorConduitSearchFieldSpecification())
+        ->setKey('leasePHID')
+        ->setType('string')
+        ->setDescription(pht('PHID of the working copy lease this operation has requested.')),
+      id(new PhabricatorConduitSearchFieldSpecification())
+        ->setKey('repositoryPHID')
+        ->setType('string')
+        ->setDescription(pht('PHID of the repository this operation is working on.')),
+    );
+  }
+
+  public function getFieldValuesForConduit()
+  {
+    return array(
+      'objectPHID' => $this->getObjectPHID(),
+      'leasePHID' => $this->getWorkingCopyLeasePHID(),
+      'repositoryPHID' => $this->getRepositoryPHID(),
+    );
+  }
+
+  public function getConduitSearchAttachments()
+  {
+    return array();
+  }
 }


### PR DESCRIPTION
Adding these methods should mean that these fields get added to the conduit endpoint. I'm a bit unsure about `getObjectPHID()` and `getRepositoryPHID()` because those methods are not explicitly defined in this class, but they're called on the `DrydockRepositoryOperation` objects in DrydockRepositoryOperationSearchEnging.renderResultList(), so they must be generated methods or something?