### PR TITLE
Allow filtering drydock.operation.search by objectPHID

### DIFF
--- a/src/applications/drydock/query/DrydockRepositoryOperationSearchEngine.php
+++ b/src/applications/drydock/query/DrydockRepositoryOperationSearchEngine.php
@@ -30,6 +30,10 @@ final class DrydockRepositoryOperationSearchEngine
       $query->withOperationStates($map['states']);
     }
 
+    if ($map['objectPHIDs']) {
+      $query->withObjectPHIDs($map['objectPHIDs']);
+    }
+
     return $query;
   }
 
@@ -53,6 +57,10 @@ final class DrydockRepositoryOperationSearchEngine
         ->setKey('states')
         ->setAliases(array('state'))
         ->setOptions(DrydockRepositoryOperation::getOperationStateNameMap()),
+      id(new PhabricatorSearchDatasourceField())
+        ->setLabel(pht('Objects'))
+        ->setKey('objectPHIDs')
+        ->setAliases(array('object', 'objects', 'objectPHID', 'revision', 'revisionPHID', 'revisions', 'revisionPHIDs')),
     );
   }
 


### PR DESCRIPTION
This will allow us to fetch the operations for a specific revision. Copied the bits from the way that repositoryPHIDs is specified.

Unsure if I went overboard with the aliases, but yeah.
Luckily, `DrydockRepositoryOperationQuery` already implements filtering by object PHID!