### PR TITLE
Add the comment inline suggestion to the transaction.search conduit endpoint

### DIFF
--- a/src/applications/transactions/conduit/TransactionSearchConduitAPIMethod.php
+++ b/src/applications/transactions/conduit/TransactionSearchConduitAPIMethod.php
@@ -206,10 +206,12 @@ EOREMARKUP
             // removed comments.
             $content = array(
               'raw' => '',
+              'inlineSuggestion' => '',
             );
           } else {
             $content = array(
               'raw' => (string)$comment->getContent(),
+              'inlineSuggestion' => (string)$comment->getContentState()->getContentSuggestionText()
             );
           }
 

--- a/src/applications/transactions/conduit/TransactionSearchConduitAPIMethod.php
+++ b/src/applications/transactions/conduit/TransactionSearchConduitAPIMethod.php
@@ -198,7 +198,7 @@ EOREMARKUP
       if ($comments) {
         $removed = head($comments)->getIsDeleted();
 
-        /** @var PhabricatorInlineComment $comment */
+        /** @var PhabricatorApplicationTransactionComment $comment */
         foreach ($comments as $comment) {
           if ($removed) {
             // If the most recent version of the comment has been removed,
@@ -211,9 +211,13 @@ EOREMARKUP
             );
           } else {
             $inline_suggestion = null;
-            $comment_state = $comment->getContentState();
-            if ($comment_state->getContentHasSuggestion()) {
-              $inline_suggestion = (string)$comment_state->getContentSuggestionText();
+            // If we're looking at a comment on a differential transaction, then we can get inline suggestion data
+            if ($comment instanceof DifferentialTransactionComment) {
+              $inline_comment = $comment->newInlineCommentObject();
+              $comment_state = $inline_comment->getContentState();
+              if ($comment_state->getContentHasSuggestion()) {
+                $inline_suggestion = (string)$comment_state->getContentSuggestionText();
+              }
             }
             $content = array(
               'raw' => (string)$comment->getContent(),

--- a/src/applications/transactions/conduit/TransactionSearchConduitAPIMethod.php
+++ b/src/applications/transactions/conduit/TransactionSearchConduitAPIMethod.php
@@ -198,6 +198,7 @@ EOREMARKUP
       if ($comments) {
         $removed = head($comments)->getIsDeleted();
 
+        /** @var PhabricatorInlineComment $comment */
         foreach ($comments as $comment) {
           if ($removed) {
             // If the most recent version of the comment has been removed,

--- a/src/applications/transactions/conduit/TransactionSearchConduitAPIMethod.php
+++ b/src/applications/transactions/conduit/TransactionSearchConduitAPIMethod.php
@@ -206,12 +206,17 @@ EOREMARKUP
             // removed comments.
             $content = array(
               'raw' => '',
-              'inlineSuggestion' => '',
+              'inlineSuggestion' => null,
             );
           } else {
+            $inline_suggestion = null;
+            $comment_state = $comment->getContentState();
+            if ($comment_state->getContentHasSuggestion()) {
+              $inline_suggestion = (string)$comment_state->getContentSuggestionText();
+            }
             $content = array(
               'raw' => (string)$comment->getContent(),
-              'inlineSuggestion' => (string)$comment->getContentState()->getContentSuggestionText()
+              'inlineSuggestion' => $inline_suggestion,
             );
           }
 


### PR DESCRIPTION
It was mentioned that this doesn't exist in this API endpoint at the moment. It would be very helpful, so let's add it!

Here's the method to fetch the inline suggestion:
https://github.com/thought-machine/phorge/blob/tm-master/src/infrastructure/diff/inline/PhabricatorDiffInlineCommentContentState.php#L28

And here's the method to get that comment state:
https://github.com/thought-machine/phorge/blob/tm-master/src/infrastructure/diff/interface/PhabricatorInlineComment.php#L362

I'm not able to test locally, but we can test this on our dev environment after landing (or before if we want to deploy from a fork)